### PR TITLE
add toast for saving a proof and updating a definition

### DIFF
--- a/client/package-lock.json
+++ b/client/package-lock.json
@@ -20,6 +20,7 @@
         "react-dom": "^18.3.1",
         "react-router-dom": "^6.26.1",
         "react-scripts": "5.0.1",
+        "react-toastify": "^10.0.6",
         "sass": "^1.77.8",
         "use-double-click": "^1.0.5",
         "web-vitals": "^2.1.4"
@@ -6803,6 +6804,15 @@
         "string-width": "^4.2.0",
         "strip-ansi": "^6.0.0",
         "wrap-ansi": "^7.0.0"
+      }
+    },
+    "node_modules/clsx": {
+      "version": "2.1.1",
+      "resolved": "https://registry.npmjs.org/clsx/-/clsx-2.1.1.tgz",
+      "integrity": "sha512-eYm0QWBtUrBWZWG0d386OGAw16Z995PiOVo2B7bjWSbHedGl5e0ZWaq65kOGgUSNesEIDkB9ISbTg/JK9dhCZA==",
+      "license": "MIT",
+      "engines": {
+        "node": ">=6"
       }
     },
     "node_modules/co": {
@@ -17367,6 +17377,19 @@
       },
       "engines": {
         "node": ">=10"
+      }
+    },
+    "node_modules/react-toastify": {
+      "version": "10.0.6",
+      "resolved": "https://registry.npmjs.org/react-toastify/-/react-toastify-10.0.6.tgz",
+      "integrity": "sha512-yYjp+omCDf9lhZcrZHKbSq7YMuK0zcYkDFTzfRFgTXkTFHZ1ToxwAonzA4JI5CxA91JpjFLmwEsZEgfYfOqI1A==",
+      "license": "MIT",
+      "dependencies": {
+        "clsx": "^2.1.0"
+      },
+      "peerDependencies": {
+        "react": ">=18",
+        "react-dom": ">=18"
       }
     },
     "node_modules/react-transition-group": {

--- a/client/package.json
+++ b/client/package.json
@@ -15,6 +15,7 @@
     "react-dom": "^18.3.1",
     "react-router-dom": "^6.26.1",
     "react-scripts": "5.0.1",
+    "react-toastify": "^10.0.6",
     "sass": "^1.77.8",
     "use-double-click": "^1.0.5",
     "web-vitals": "^2.1.4"

--- a/client/src/components/Definitions.jsx
+++ b/client/src/components/Definitions.jsx
@@ -11,6 +11,7 @@ import { useFormValidation } from "../hooks/useFormValidation";
 import { useFormSubmit } from "../hooks/useFormSubmit";
 import { useEffect, useState } from 'react';
 import erService from '../services/erService';
+import { toast } from "react-toastify";
 
 export default function Definitions({ toggleDefinitionsWindow }) {
   const [showCreateDefinition, setShowCreateDefinition] = useState(false);
@@ -78,7 +79,11 @@ function CreateDefinition({
 
     if (edit) {
       try {
-        const newDefinition = await erService.editDefinition(definition);
+        const newDefinition = await toast.promise(erService.editDefinition(definition), {
+          pending: 'Updating definition...',
+          success: 'Definition updated successfully.',
+          error: 'An error occurred. Please try again.'
+        });
         setErrors([]);
 
         updateDefinition({

--- a/client/src/components/Definitions.jsx
+++ b/client/src/components/Definitions.jsx
@@ -1,17 +1,17 @@
-import "../scss/_definitions.scss";
-import Form from "react-bootstrap/Form";
-import Col from "react-bootstrap/Col";
-import Row from "react-bootstrap/Row";
-import Alert from "react-bootstrap/Alert";
-import Button from "react-bootstrap/esm/Button";
-import Accordion from "react-bootstrap/Accordion";
-import validateField from "../utils/definitionsFormValidation";
-import { useInputState } from "../hooks/useInputState";
-import { useFormValidation } from "../hooks/useFormValidation";
-import { useFormSubmit } from "../hooks/useFormSubmit";
+import '../scss/_definitions.scss';
+import Form from 'react-bootstrap/Form';
+import Col from 'react-bootstrap/Col';
+import Row from 'react-bootstrap/Row';
+import Alert from 'react-bootstrap/Alert';
+import Button from 'react-bootstrap/esm/Button';
+import Accordion from 'react-bootstrap/Accordion';
+import validateField from '../utils/definitionsFormValidation';
+import { useInputState } from '../hooks/useInputState';
+import { useFormValidation } from '../hooks/useFormValidation';
+import { useFormSubmit } from '../hooks/useFormSubmit';
 import { useEffect, useState } from 'react';
 import erService from '../services/erService';
-import { toast } from "react-toastify";
+import { toast } from 'react-toastify';
 
 export default function Definitions({ toggleDefinitionsWindow }) {
   const [showCreateDefinition, setShowCreateDefinition] = useState(false);
@@ -79,11 +79,14 @@ function CreateDefinition({
 
     if (edit) {
       try {
-        const newDefinition = await toast.promise(erService.editDefinition(definition), {
-          pending: 'Updating definition...',
-          success: 'Definition updated successfully.',
-          error: 'An error occurred. Please try again.'
-        });
+        const newDefinition = await toast.promise(
+          erService.editDefinition(definition),
+          {
+            pending: 'Updating definition...',
+            success: 'Definition updated successfully.',
+            error: 'An error occurred. Please try again.'
+          }
+        );
         setErrors([]);
 
         updateDefinition({
@@ -290,11 +293,15 @@ function ShowDefinitions({ onUpdate, toggleDefinitionsWindow }) {
   };
 
   const applyDefinition = async (id) => {
-    await toast.promise(erService.useDefinition(id), {
-      pending: 'Applying definition...',
-      success: 'Definition applied successfully.',
-      error: 'An error occurred. Please try again.'
-    });
+    try {
+      await toast.promise(erService.useDefinition(id), {
+        pending: 'Applying definition...',
+        success: 'Definition applied successfully.',
+        error: 'An error occurred. Please try again.'
+      });
+    } catch (error) {
+      console.error(error);
+    }
   };
 
   useEffect(() => {

--- a/client/src/components/Definitions.jsx
+++ b/client/src/components/Definitions.jsx
@@ -258,13 +258,13 @@ function ShowDefinitions({ onUpdate, toggleDefinitionsWindow }) {
       'Are you sure you want to delete this definition?'
     );
     if (!confirm) return;
+    const deleted = await toast.promise(erService.deleteDefinition(id), {
+      pending: 'Deleting definition...',
+      success: 'Definition deleted successfully.',
+      error: 'An error occurred. Please try again.'
+    });
 
-    const deleted = await erService.deleteDefinition(id);
-
-    if (!deleted) {
-      alert('Error deleting definition.');
-      return;
-    }
+    if (!deleted) return;
 
     const definitions = JSON.parse(sessionStorage.getItem('definitions')) || [];
     const updatedDefinitions = definitions.filter((def) => def.id !== id);
@@ -289,13 +289,11 @@ function ShowDefinitions({ onUpdate, toggleDefinitionsWindow }) {
     setEdit(true);
   };
 
-  const applyDefinition = (id) => {
-    erService.useDefinition(id).then((created) => {
-      if (!created) {
-        alert('Error using definition.');
-      } else {
-        alert('Definition applied successfully.');
-      }
+  const applyDefinition = async (id) => {
+    await toast.promise(erService.useDefinition(id), {
+      pending: 'Applying definition...',
+      success: 'Definition applied successfully.',
+      error: 'An error occurred. Please try again.'
     });
   };
 

--- a/client/src/layouts/MainLayout.js
+++ b/client/src/layouts/MainLayout.js
@@ -2,6 +2,8 @@ import React from 'react';
 import Header from '../components/Header';
 import Footer from '../components/Footer';
 import '../scss/_main-layout.scss';
+import { ToastContainer } from 'react-toastify';
+import 'react-toastify/dist/ReactToastify.css';
 
 /**
  * MainLayout serves as a layout wrapper for the application.
@@ -9,6 +11,18 @@ import '../scss/_main-layout.scss';
 const MainLayout = ({ children }) => {
   return (
     <>
+      <ToastContainer
+        position="top-right"
+        autoClose={5000}
+        hideProgressBar={false}
+        newestOnTop={false}
+        closeOnClick
+        rtl={false}
+        pauseOnFocusLoss
+        draggable
+        pauseOnHover
+        theme="light"
+      />
       <Header />
       <main className="main-container">{children}</main>
       <Footer />

--- a/client/src/pages/ERRacket.js
+++ b/client/src/pages/ERRacket.js
@@ -29,6 +29,7 @@ import {
 import { useDefinitionsWindow } from "../hooks/useDefinitionsWindow";
 import erService from "../services/erService";
 import { useLocation } from "react-router-dom";
+import { toast } from "react-toastify";
 
 /**
  * ERRacket component facilitates the Equational Reasoning Racket.
@@ -147,7 +148,11 @@ const ERRacket = () => {
     };
 
     try {
-      await erService.saveProof(proof);
+      await toast.promise(erService.saveProof(proof), {
+        pending: "Saving proof...",
+        success: "Proof saved!",
+        error: "Error saving proof!"
+      });
     } catch (error) {
       console.error(error);
     }

--- a/client/src/services/erService.js
+++ b/client/src/services/erService.js
@@ -93,13 +93,17 @@ const substitution = async (data) => {
 };
 
 const saveProof = async (proof) => {
-  try {
-    const response = await axiosInstance.post(`${API_GATEWAY}/er-save`, proof);
-    return response.data;
-  } catch (error) {
-    handleServiceError(error, "Error during proof saving:");
-    throw error;
-  }
+  return new Promise((resolve, reject) => {
+    axiosInstance
+      .post(`${API_GATEWAY}/er-save`, proof)
+      .then((response) => {
+        resolve(response.data);
+      })
+      .catch((error) => {
+        handleServiceError(error, "Error during proof saving:");
+        reject(error);
+      });
+  });
 };
 
 const getRacketProofs = async ({ page = 1, query = "" }) => {
@@ -144,16 +148,17 @@ const useDefinition = async (id) => {
 };
 
 const editDefinition = async (definition) => {
-  try {
-    const response = await axiosInstance.post(
-      `${API_GATEWAY}/edit-definition/`,
-      definition
-    );
-    return response.data;
-  } catch (error) {
-    handleServiceError(error, "Error during definition update:");
-    throw error;
-  }
+  return new Promise((resolve, reject) => {
+    axiosInstance
+      .post(`${API_GATEWAY}/edit-definition/`, definition)
+      .then((response) => {
+        resolve(response.data);
+      })
+      .catch((error) => {
+        handleServiceError(error, "Error during definition update:");
+        reject(error);
+      });
+  });
 };
 
 const deleteDefinition = async (id) => {

--- a/client/src/services/erService.js
+++ b/client/src/services/erService.js
@@ -137,14 +137,17 @@ const getUserDefinitions = async () => {
 };
 
 const useDefinition = async (id) => {
-  try {
-    await axiosInstance.get(
-      `${API_GATEWAY}/use-definition/${id}`
-    );
-    return true;
-  } catch (error) {
-    return false;
-  }
+  return new Promise((resolve, reject) => {
+    axiosInstance
+      .get(`${API_GATEWAY}/use-definition/${id}`)
+      .then((response) => {
+        resolve(response.data);
+      })
+      .catch((error) => {
+        handleServiceError(error, "Error during definition usage:");
+        reject(error);
+      });
+  });
 };
 
 const editDefinition = async (definition) => {
@@ -162,12 +165,17 @@ const editDefinition = async (definition) => {
 };
 
 const deleteDefinition = async (id) => {
-  try {
-    await axiosInstance.delete(`${API_GATEWAY}/delete-definition/${id}/`);
-    return true;
-  } catch (error) {
-    return false;
-  }
+  return new Promise((resolve, reject) => {
+    axiosInstance
+      .delete(`${API_GATEWAY}/delete-definition/${id}/`)
+      .then(() => {
+        resolve(true);
+      })
+      .catch((error) => {
+        handleServiceError(error, "Error during definition deletion:");
+        reject(error);
+      });
+  });
 };
 
 const erService = {


### PR DESCRIPTION
This adds feedback so the user knows the state of their proof when they save a proof.
This also adds feedback when a user updates a definition.

**Ensure to run `npm install` in the client directory before starting the client**